### PR TITLE
fix for cloudinit addSSHKeys method

### DIFF
--- a/pkg/vsphere/internal/vapp_helper.go
+++ b/pkg/vsphere/internal/vapp_helper.go
@@ -18,7 +18,6 @@ package internal
 
 import (
 	"bytes"
-	"encoding/base64"
 	"fmt"
 	"strings"
 	"text/template"
@@ -65,11 +64,7 @@ func addSSHKeysSection(userdata string, sshKeys []string) (string, error) {
 	if len(sshKeys) == 0 {
 		return userdata, nil
 	}
-	decoded, err := base64.StdEncoding.DecodeString(userdata)
-	if err != nil {
-		return "", errors.Wrap(err, "Decoding userdata failed")
-	}
-	s := string(decoded)
+	s := userdata
 	if strings.Contains(s, "ssh_authorized_keys:") {
 		return "", fmt.Errorf("userdata already contains key `ssh_authorized_keys`")
 	}
@@ -77,5 +72,5 @@ func addSSHKeysSection(userdata string, sshKeys []string) (string, error) {
 	for _, key := range sshKeys {
 		s = s + fmt.Sprintf("- %q\n", key)
 	}
-	return base64.StdEncoding.EncodeToString([]byte(s)), nil
+	return s, nil
 }

--- a/pkg/vsphere/internal/vapp_helper_test.go
+++ b/pkg/vsphere/internal/vapp_helper_test.go
@@ -58,11 +58,21 @@ func TestCoreOSIgnition(t *testing.T) {
 
 func TestAddSSHKeys(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
-	userdata := "I2Nsb3VkLWNvbmZpZwpydW5jbWQ6Ci0gJ2VjaG8gMTI3LjAuMC4xIGBob3N0bmFtZWAgPj4gL2V0Yy9ob3N0cy14eHgnCg=="
+	userdata := `#cloud-config
+runcmd:
+- 'echo 127.0.0.1 $(hostname) >> /etc/hosts-xxx'
+`
 
 	newUserdata, err := addSSHKeysSection(userdata, []string{"ssh1", "ssh2"})
 	if err != nil {
 		t.Errorf("addSSHKeysSection failed with %s", err)
 	}
-	g.Expect(newUserdata).To(gomega.Equal("I2Nsb3VkLWNvbmZpZwpydW5jbWQ6Ci0gJ2VjaG8gMTI3LjAuMC4xIGBob3N0bmFtZWAgPj4gL2V0Yy9ob3N0cy14eHgnCgpzc2hfYXV0aG9yaXplZF9rZXlzOgotICJzc2gxIgotICJzc2gyIgo="))
+	g.Expect(newUserdata).To(gomega.Equal(`#cloud-config
+runcmd:
+- 'echo 127.0.0.1 $(hostname) >> /etc/hosts-xxx'
+
+ssh_authorized_keys:
+- "ssh1"
+- "ssh2"
+`))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This provider supports ignition for core-os and cloudinit for other linux like gardenlinux.
For cloudinit this PR fixes the addition of ssh keys. Here it was wrongly assumpted that the passed userdata is still base64 encoded.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
fix adding ssh keys for operation systems with cloudinit 
```