### PR TITLE
Updated the error codes

### DIFF
--- a/pkg/vsphere/machine_server.go
+++ b/pkg/vsphere/machine_server.go
@@ -68,7 +68,8 @@ func (ms *MachinePlugin) CreateMachine(ctx context.Context, req *driver.CreateMa
 
 	// check if the machineClass is of the supported provider
 	if req.MachineClass.Provider != Providervsphere {
-		return nil, fmt.Errorf("Requested provider is '%s'. We support only '%s'", req.MachineClass.Provider, Providervsphere)
+		err := fmt.Errorf("Requested provider is '%s'. We support only '%s'", req.MachineClass.Provider, Providervsphere)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	providerSpec, err := decodeProviderSpecAndSecret(req.MachineClass, req.Secret)
@@ -110,7 +111,8 @@ func (ms *MachinePlugin) DeleteMachine(ctx context.Context, req *driver.DeleteMa
 
 	// check if the machineClass is of the supported provider
 	if req.MachineClass.Provider != Providervsphere {
-		return nil, fmt.Errorf("Requested provider is '%s'. We support only '%s'", req.MachineClass.Provider, Providervsphere)
+		err := fmt.Errorf("Requested provider is '%s'. We support only '%s'", req.MachineClass.Provider, Providervsphere)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	providerSpec, err := decodeProviderSpecAndSecret(req.MachineClass, req.Secret)
@@ -150,7 +152,8 @@ func (ms *MachinePlugin) GetMachineStatus(ctx context.Context, req *driver.GetMa
 
 	// check if the machineClass is of the supported provider
 	if req.MachineClass.Provider != Providervsphere {
-		return nil, fmt.Errorf("Requested provider is '%s'. We support only '%s'", req.MachineClass.Provider, Providervsphere)
+		err := fmt.Errorf("Requested provider is '%s'. We support only '%s'", req.MachineClass.Provider, Providervsphere)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	providerSpec, err := decodeProviderSpecAndSecret(req.MachineClass, req.Secret)
@@ -192,7 +195,8 @@ func (ms *MachinePlugin) ListMachines(ctx context.Context, req *driver.ListMachi
 
 	// check if the machineClass is of the supported provider
 	if req.MachineClass.Provider != Providervsphere {
-		return nil, fmt.Errorf("Requested provider is '%s'. We support only '%s'", req.MachineClass.Provider, Providervsphere)
+		err := fmt.Errorf("Requested provider is '%s'. We support only '%s'", req.MachineClass.Provider, Providervsphere)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	providerSpec, err := decodeProviderSpecAndSecret(req.MachineClass, req.Secret)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds proper error codes on validating the provider in the MachineClass

**Which issue(s) this PR fixes**:
Fixes [#599](https://github.com/gardener/machine-controller-manager/issues/599)

**Special notes for your reviewer**:
This is an update over the already merged [PR](https://github.com/gardener/machine-controller-manager-provider-vsphere/pull/11)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```