### PR TITLE
Use distroless as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,12 @@ COPY . .
 RUN .ci/build
 
 #############      base                                     #############
-FROM alpine:3.15.4 AS base
+FROM gcr.io/distroless/static-debian11:nonroot AS base
 
-RUN apk add --update bash curl tzdata
-WORKDIR /
 
 #############      machine-controller               #############
 FROM base AS machine-controller
+WORKDIR /
 
 COPY --from=builder /go/src/github.com/gardener/machine-controller-manager-provider-vsphere/bin/rel/machine-controller /machine-controller
 ENTRYPOINT ["/machine-controller"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Use distroless as base image

**Special notes for your reviewer**:
https://github.com/gardener/backlog/issues/7

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Use distroless as base image
```