### PR TITLE
Update revendor make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,8 @@ start:
 
 .PHONY: revendor
 revendor:
-	@env GO111MODULE=on go mod vendor -v
 	@env GO111MODULE=on go mod tidy -v
+	@env GO111MODULE=on go mod vendor -v
 
 #########################################
 # Rules for testing


### PR DESCRIPTION
**What this PR does / why we need it**:
The make rule update would enable the autovendoring MCM script to run without error in certain cases.
Refer https://github.com/gardener/machine-controller-manager-provider-openstack/pull/64#discussion_r912971792
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```