### PR TITLE
rename coreos to ignition in vapp properties and update to golang 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder                                  #############
-FROM golang:1.17.11 AS builder
+FROM golang:1.18.4 AS builder
 
 WORKDIR /go/src/github.com/gardener/machine-controller-manager-provider-vsphere
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/machine-controller-manager-provider-vsphere
 
-go 1.17
+go 1.18
 
 require (
 	github.com/gardener/machine-controller-manager v0.46.0

--- a/pkg/vsphere/internal/clone.go
+++ b/pkg/vsphere/internal/clone.go
@@ -195,7 +195,7 @@ func (cmd *clone) Run(ctx context.Context, client *govmomi.Client) error {
 			if err != nil {
 				return errors.Wrap(err, "setting VApp (coreos64)")
 			}
-			vapp = &api.VApp{Properties: map[string]string{"guestinfo.coreos.config.data": ignitionContent}}
+			vapp = &api.VApp{Properties: map[string]string{"guestinfo.ignition.config.data": ignitionContent}}
 		case "other4xLinux64Guest":
 			// experimental support for flatcar
 			// other4xLinux64Guest is used as label for flatcar
@@ -220,7 +220,7 @@ func (cmd *clone) Run(ctx context.Context, client *govmomi.Client) error {
 			if err != nil {
 				return errors.Wrap(err, "setting VApp (flatcar64)")
 			}
-			vapp = &api.VApp{Properties: map[string]string{"guestinfo.coreos.config.data": ignitionContent}}
+			vapp = &api.VApp{Properties: map[string]string{"guestinfo.ignition.config.data": ignitionContent}}
 		default:
 			// Provide cloud-init as VApp.
 			// This assumes, that the image defines a VApp with the properties


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #39 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
- support most recent flatcar versions
- build with golang 1.18.4
```