### PR TITLE
Upgrade golang to 1.19.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder                                  #############
-FROM golang:1.19.2 AS builder
+FROM golang:1.19.4 AS builder
 
 WORKDIR /go/src/github.com/gardener/machine-controller-manager-provider-vsphere
 COPY . .


### PR DESCRIPTION
Signed-off-by: Brian Topping <brian.topping@sap.com>
Upgrade golang to 1.19.4

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```