### PR TITLE
Add cve categorization for mcm-provider-vsphere

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -14,6 +14,15 @@ machine-controller-manager-provider-vsphere:
                 build: ~
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-vsphere'
+            resource_labels:
+            - name: 'gardener.cloud/cve-categorisation'
+              value:
+                network_exposure: 'protected'
+                authentication_enforced: false
+                user_interaction: 'gardener-operator'
+                confidentiality_requirement: 'high'
+                integrity_requirement: 'high'
+                availability_requirement: 'low'
     steps_template: &steps_anchor
       steps:
         check:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add cve categorization for mcm-provider-vsphere.

The categorization was initially defined here and it transferred as defined to the mcm-provider-vsphere repository: 
https://github.com/gardener/gardener-extension-provider-vsphere/pull/362 

We move the cve categorization to the mcm-provider-vsphere repository as the categorization can't be taken into consideration when it is defined in the respective provider extension project. Once this behaviour has changed we can remove the categorisation here again.

**Release note**:
```other operator
CVE categorization for mcm-provider-vsphere has been added.
```