### PR TITLE
Moved Declaration of dynamic content from Makefile to .env file for VSPHERE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /dev
 /test
 /logs
-
+.env
 .vscode
 .idea
 *.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+-include .env
+
 PROVIDER_NAME       := Vsphere
 PROJECT_NAME        := gardener
 BINARY_PATH         := bin/
 IMAGE_REPOSITORY    := eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-vsphere
 IMAGE_TAG           := $(shell cat VERSION)
-
--include .env
 
 #########################################
 # Rules for starting machine-controller locally

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,8 @@ PROJECT_NAME        := gardener
 BINARY_PATH         := bin/
 IMAGE_REPOSITORY    := eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-vsphere
 IMAGE_TAG           := $(shell cat VERSION)
-CONTROL_NAMESPACE   := default
-CONTROL_KUBECONFIG  := dev/target-kubeconfig.yaml
-TARGET_KUBECONFIG   := dev/target-kubeconfig.yaml
+
+include .env
 
 #########################################
 # Rules for starting machine-controller locally

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BINARY_PATH         := bin/
 IMAGE_REPOSITORY    := eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-vsphere
 IMAGE_TAG           := $(shell cat VERSION)
 
-include .env
+-include .env
 
 #########################################
 # Rules for starting machine-controller locally


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates Makefile content to import dynamic content from the .env file.

**Which issue(s) this PR fixes**:
Fixes -> https://github.com/gardener/machine-controller-manager/issues/846

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```