### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -5,25 +5,6 @@ machine-controller-manager-provider-vsphere:
         inject_effective_version: true
       component_descriptor: ~
   inherit:
-    publish_template: &publish_anchor
-      publish:
-        dockerimages:
-          machine-controller-manager-provider-vsphere:
-            inputs:
-              repos:
-                source: ~ # default
-              steps:
-                build: ~
-            image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-vsphere'
-            resource_labels:
-            - name: 'gardener.cloud/cve-categorisation'
-              value:
-                network_exposure: 'protected'
-                authentication_enforced: false
-                user_interaction: 'gardener-operator'
-                confidentiality_requirement: 'high'
-                integrity_requirement: 'high'
-                availability_requirement: 'low'
     steps_template: &steps_anchor
       steps:
         check:
@@ -40,12 +21,31 @@ machine-controller-manager-provider-vsphere:
         component_descriptor:
           retention_policy: 'clean-snapshots'
         draft_release: ~
-        <<: *publish_anchor
+        publish:
+          dockerimages: &default_images
+            machine-controller-manager-provider-vsphere: &mcmpv-image
+              inputs:
+                repos:
+                  source: ~ # default
+                steps:
+                  build: ~
+              image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/machine-controller-manager-provider-vsphere
+              resource_labels:
+              - name: 'gardener.cloud/cve-categorisation'
+                value:
+                  network_exposure: 'protected'
+                  authentication_enforced: false
+                  user_interaction: 'gardener-operator'
+                  confidentiality_requirement: 'high'
+                  integrity_requirement: 'high'
+                  availability_requirement: 'low'
     pull-request:
       <<: *steps_anchor
       traits:
         pull-request: ~
-        <<: *publish_anchor
+        publish:
+          dockerimages:
+            <<: *default_images
     create-upgrade-prs:
       traits:
         cronjob:
@@ -54,12 +54,17 @@ machine-controller-manager-provider-vsphere:
     release:
       <<: *steps_anchor
       traits:
-        <<: *publish_anchor
         version:
           preprocess: 'finalize'
         component_descriptor: ~
         release:
           nextversion: 'bump_minor'
+        publish:
+          dockerimages:
+            <<: *default_images
+            machine-controller-manager-provider-vsphere:
+              <<: *mcmpv-image
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager-provider-vsphere
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,7 +1,9 @@
 machine-controller-manager-provider-vsphere:
-  template: 'default'
   base_definition:
-    repo: ~
+    traits:
+      version:
+        inject_effective_version: true
+      component_descriptor: ~
   inherit:
     publish_template: &publish_anchor
       publish:
@@ -12,7 +14,6 @@ machine-controller-manager-provider-vsphere:
                 source: ~ # default
               steps:
                 build: ~
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-vsphere'
             resource_labels:
             - name: 'gardener.cloud/cve-categorisation'
@@ -32,14 +33,10 @@ machine-controller-manager-provider-vsphere:
           output_dir: 'binary'
         test:
           image: 'europe-docker.pkg.dev/gardener-project/releases/testmachinery/base-step:stable'
-    version_template: &version_anchor
-      version:
-        inject_effective_version: true
   jobs:
     head-update:
       <<: *steps_anchor
       traits:
-        <<: *version_anchor
         component_descriptor:
           retention_policy: 'clean-snapshots'
         draft_release: ~
@@ -47,13 +44,10 @@ machine-controller-manager-provider-vsphere:
     pull-request:
       <<: *steps_anchor
       traits:
-        <<: *version_anchor
         pull-request: ~
         <<: *publish_anchor
     create-upgrade-prs:
       traits:
-        component_descriptor: ~
-        version: ~
         cronjob:
           interval: '5m'
         update_component_deps: ~
@@ -63,6 +57,7 @@ machine-controller-manager-provider-vsphere:
         <<: *publish_anchor
         version:
           preprocess: 'finalize'
+        component_descriptor: ~
         release:
           nextversion: 'bump_minor'
         slack:
@@ -74,4 +69,3 @@ machine-controller-manager-provider-vsphere:
             internal_scp_workspace_vmware:
               channel_name: 'C02DYTGSUNQ' #sap-tech-gardener-on-vmware
               slack_cfg_name: 'scp_workspace'
-        component_descriptor: ~

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 PROVIDER_NAME       := Vsphere
 PROJECT_NAME        := gardener
 BINARY_PATH         := bin/
-IMAGE_REPOSITORY    := eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-vsphere
+IMAGE_REPOSITORY    := europe-docker.pkg.dev/gardener-project/public/gardener/machine-controller-manager-provider-vsphere
 IMAGE_TAG           := $(shell cat VERSION)
 
 #########################################

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -14,14 +14,14 @@ spec:
     spec:
       containers:
       - name: cmi-plugin
-        image: eu.gcr.io/gardener-project/test/machine-controller-manager-provider-vsphere:v0.1.0-dev
+        image: europe-docker.pkg.dev/gardener-project/public/machine-controller-manager-provider-vsphere:v0.1.0-dev
         imagePullPolicy: Always
         #imagePullPolicy: IfNotPresent
         command:
         - ./cmi-plugin
         - --endpoint=tcp://127.0.0.1:8080
       - name: machine-controller-manager
-        image: eu.gcr.io/gardener-project/gardener/machine-controller-manager:1.0.0
+        image: europe-docker.pkg.dev/gardener-project/public/gardener/machine-controller-manager:1.0.0
         command:
           - ./machine-controller-manager
           - --v=2


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
